### PR TITLE
Fix v0.1.0-beta release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,13 @@ jobs:
             -e "s|{{SHA_AARCH64_MACOS}}|${sha_aarch64_macos}|g" \
             packaging/homebrew/zypher.rb.template > dist/zypher.rb
 
+      - name: Upload rendered Homebrew formula
+        uses: actions/upload-artifact@v4
+        with:
+          name: homebrew-formula
+          path: dist/zypher.rb
+          if-no-files-found: error
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
@@ -180,12 +187,10 @@ jobs:
 
     steps:
       - name: Download rendered formula
-        uses: robinraju/release-downloader@v1
+        uses: actions/download-artifact@v4
         with:
-          repository: ${{ env.ZYPHER_REPOSITORY }}
-          tag: v${{ needs.github-release.outputs.version }}
-          fileName: zypher.rb
-          out-file-path: dist
+          name: homebrew-formula
+          path: dist
 
       - name: Upload formula to tap
         env:


### PR DESCRIPTION
Fixes the v0.1.0-beta release workflow after the first release run surfaced two CI issues.\n\nChanges:\n- Allow npm metadata preparation to keep an unchanged package version with `--allow-same-version`, fixing `npm error Version not changed`.\n- Pass the rendered Homebrew formula between jobs with workflow artifacts instead of downloading it back from the just-created GitHub release, avoiding transient release API failures.\n\nValidated locally:\n- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`\n- `npm --prefix npm version 0.1.0-beta --no-git-tag-version --allow-same-version`