### PR TITLE
ci: require release publish credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,8 +171,8 @@ jobs:
         run: |
           set -eu
           if [ -z "${NODE_AUTH_TOKEN}" ]; then
-            echo "Skipping npm publish because NPM_TOKEN is not configured."
-            exit 0
+            echo "NPM_TOKEN is required to publish the npm release."
+            exit 1
           fi
           tag=latest
           if [ "${PRERELEASE}" = "true" ]; then
@@ -200,8 +200,8 @@ jobs:
         run: |
           set -eu
           if [ -z "${HOMEBREW_TAP_REPO}" ] || [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
-            echo "Skipping Homebrew tap update because HOMEBREW_TAP_REPO or HOMEBREW_TAP_TOKEN is not configured."
-            exit 0
+            echo "HOMEBREW_TAP_REPO and HOMEBREW_TAP_TOKEN are required to publish the Homebrew release."
+            exit 1
           fi
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${HOMEBREW_TAP_REPO}.git" homebrew-tap
           mkdir -p homebrew-tap/Formula

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,20 +2,19 @@
 
 Zypher releases are driven by annotated Git tags. Tags matching `v*` trigger the
 release workflow, which builds all supported CLI targets, publishes a GitHub
-release, publishes the npm package when npm credentials are configured, and
-renders a Homebrew formula with release checksums.
+release, publishes the npm package, renders a Homebrew formula with release
+checksums, and pushes that formula to the Homebrew tap.
 
 ## Required Secrets
 
-- `NPM_TOKEN` publishes the `zypher` package to npm.
+- `NPM_TOKEN` publishes the `@zypher-org/zypher` package to npm. The installed
+  binary command remains `zypher`.
 - `HOMEBREW_TAP_REPO` names the tap repository to update, for example
   `zypher-org/homebrew-tap`.
 - `HOMEBREW_TAP_TOKEN` pushes the rendered formula to the tap repository.
 
-The GitHub release and formula asset are created even when npm or Homebrew tap
-secrets are absent. Missing npm credentials skip npm publishing. Missing
-Homebrew tap credentials skip the tap update after uploading `zypher.rb` to the
-GitHub release.
+Missing npm or Homebrew tap credentials fail the release workflow. A green
+release run means GitHub assets, npm, and Homebrew tap publishing all completed.
 
 ## Supported Release Assets
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zypher",
+  "name": "@zypher-org/zypher",
   "version": "0.1.0-beta",
   "description": "A batteries-included web framework built the Zig way.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Make npm and Homebrew publishing fail loudly when required credentials are missing instead of reporting a green release run after skipping publication.

Use the scoped npm package name @zypher-org/zypher because the unscoped zypher package is unavailable on npm. Keep the installed CLI binary name as zypher and update release docs to describe the required secrets and success contract.